### PR TITLE
Remove "pkg_resources deprecated" warning

### DIFF
--- a/gym_pusht/envs/pusht.py
+++ b/gym_pusht/envs/pusht.py
@@ -1,10 +1,16 @@
 import collections
 import os
+import warnings
 
 import cv2
 import gymnasium as gym
 import numpy as np
-import pygame
+
+with warnings.catch_warnings():
+    # Filter out DeprecationWarnings raised from pkg_resources
+    warnings.filterwarnings("ignore", "pkg_resources is deprecated as an API", category=DeprecationWarning)
+    import pygame
+
 import pymunk
 import pymunk.pygame_util
 import shapely.geometry as sg


### PR DESCRIPTION
Silences this warning until `pygame` fixes it
```bash
DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
```