### PR TITLE
Add keypoints mode, and fix order of operations in `add_tee`

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,10 @@ If `obs_type` is set to `state`, the observation space is a 5-dimensional vector
 environment: [agent_x, agent_y, block_x, block_y, block_angle]. The values are in the range [0, 512] for the agent
 and block positions and [0, 2*pi] for the block angle.
 
-If `obs_type` is set to `environment_state` the observation space is a 16-dimensional vector representing the keypoint
-locations of the T (in [x0, y0, x1, y1, ...] format). The values are in the range [0, 512].
+If `obs_type` is set to `environment_state_agent_pos` the observation space is a dictionary with:
+    - `environment_state`: 16-dimensional vector representing the keypoint locations of the T (in [x0, y0, x1, y1, ...]
+        format). The values are in the range [0, 512].
+    - `agent_pos`: A 2-dimensional vector representing the position of the robot end-effector.
 
 If `obs_type` is set to `pixels`, the observation space is a 96x96 RGB image of the environment.
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ If `obs_type` is set to `state`, the observation space is a 5-dimensional vector
 environment: [agent_x, agent_y, block_x, block_y, block_angle]. The values are in the range [0, 512] for the agent
 and block positions and [0, 2*pi] for the block angle.
 
+If `obs_type` is set to `keypoints` the observation space is a 16-dimensional vector representing the keypoint
+locations of the T (in [x0, y0, x1, y1, ...] format). The values are in the range [0, 512].
+
 If `obs_type` is set to `pixels`, the observation space is a 96x96 RGB image of the environment.
 
 ### Rewards
@@ -84,7 +87,7 @@ The episode terminates when the block is at least 95% in the goal zone.
 <TimeLimit<OrderEnforcing<PassiveEnvChecker<PushTEnv<gym_pusht/PushT-v0>>>>>
 ```
 
-* `obs_type`: (str) The observation type. Can be either `state`, `pixels` or `pixels_agent_pos`. Default is `state`.
+* `obs_type`: (str) The observation type. Can be either `state`, `kepoints`, `pixels` or `pixels_agent_pos`. Default is `state`.
 
 * `block_cog`: (tuple) The center of gravity of the block if different from the center of mass. Default is `None`.
 
@@ -105,7 +108,7 @@ The episode terminates when the block is at least 95% in the goal zone.
 Passing the option `options["reset_to_state"]` will reset the environment to a specific state.
 
 > [!WARNING]
-> For legacy compatibility, the inner fonctionning has been preserved, and the state set is not the same as the
+> For legacy compatibility, the inner functioning has been preserved, and the state set is not the same as the
 > the one passed in the argument.
 
 ```python

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ If `obs_type` is set to `state`, the observation space is a 5-dimensional vector
 environment: [agent_x, agent_y, block_x, block_y, block_angle]. The values are in the range [0, 512] for the agent
 and block positions and [0, 2*pi] for the block angle.
 
-If `obs_type` is set to `keypoints` the observation space is a 16-dimensional vector representing the keypoint
+If `obs_type` is set to `environment_state` the observation space is a 16-dimensional vector representing the keypoint
 locations of the T (in [x0, y0, x1, y1, ...] format). The values are in the range [0, 512].
 
 If `obs_type` is set to `pixels`, the observation space is a 96x96 RGB image of the environment.
@@ -87,7 +87,7 @@ The episode terminates when the block is at least 95% in the goal zone.
 <TimeLimit<OrderEnforcing<PassiveEnvChecker<PushTEnv<gym_pusht/PushT-v0>>>>>
 ```
 
-* `obs_type`: (str) The observation type. Can be either `state`, `kepoints`, `pixels` or `pixels_agent_pos`. Default is `state`.
+* `obs_type`: (str) The observation type. Can be either `state`, `environment_state`, `pixels` or `pixels_agent_pos`. Default is `state`.
 
 * `block_cog`: (tuple) The center of gravity of the block if different from the center of mass. Default is `None`.
 

--- a/gym_pusht/envs/pusht.py
+++ b/gym_pusht/envs/pusht.py
@@ -511,8 +511,8 @@ class PushTEnv(gym.Env):
         shape1.filter = pymunk.ShapeFilter(mask=mask)
         shape2.filter = pymunk.ShapeFilter(mask=mask)
         body.center_of_gravity = (shape1.center_of_gravity + shape2.center_of_gravity) / 2
-        body.position = position
         body.angle = angle
+        body.position = position
         body.friction = 1
         space.add(body, shape1, shape2)
         return body, [shape1, shape2]

--- a/gym_pusht/envs/pusht.py
+++ b/gym_pusht/envs/pusht.py
@@ -430,7 +430,7 @@ class PushTEnv(gym.Env):
 
         # Add agent, block, and goal zone
         self.agent = self.add_circle(self.space, (256, 400), 15)
-        self.block = self.add_tee(self.space, (256, 300), 0)
+        self.block, self._block_shapes = self.add_tee(self.space, (256, 300), 0)
         self.goal_pose = np.array([256, 256, np.pi / 4])  # x, y, theta (in radians)
         if self.block_cog is not None:
             self.block.center_of_gravity = self.block_cog
@@ -468,6 +468,7 @@ class PushTEnv(gym.Env):
         space.add(body, shape)
         return body
 
+    @staticmethod
     def add_tee(self, space, position, angle, scale=30, color="LightSlateGray", mask=None):
         if mask is None:
             mask = pymunk.ShapeFilter.ALL_MASKS()
@@ -499,8 +500,7 @@ class PushTEnv(gym.Env):
         body.angle = angle
         body.friction = 1
         space.add(body, shape1, shape2)
-        self._block_shapes = [shape1, shape2]
-        return body
+        return body, [shape1, shape2]
 
     def get_keypoints(self):
         """Get a (8, 2) numpy array with the T keypoints.

--- a/gym_pusht/envs/pusht.py
+++ b/gym_pusht/envs/pusht.py
@@ -188,8 +188,8 @@ class PushTEnv(gym.Env):
             )
         elif self.obs_type == "environment_state":
             self.observation_space = spaces.Box(
-                low=np.zeros(8),
-                high=np.full((8,), 512),
+                low=np.zeros(16),
+                high=np.full((16,), 512),
                 dtype=np.float64,
             )
         elif self.obs_type == "pixels":

--- a/gym_pusht/envs/pusht.py
+++ b/gym_pusht/envs/pusht.py
@@ -56,9 +56,9 @@ class PushTEnv(gym.Env):
     environment: [agent_x, agent_y, block_x, block_y, block_angle]. The values are in the range [0, 512] for the agent
     and block positions and [0, 2*pi] for the block angle.
 
-    If `obs_type` is set to `keypoints` the observation space is a 16-dimensional vector representing the keypoint
-    locations of the T (in [x0, y0, x1, y1, ...] format). The values are in the range [0, 512]. See `get_keypoints` for
-    a diagram showing the location of the keypoint indices.
+    If `obs_type` is set to `environment_state` the observation space is a 16-dimensional vector representing the
+    keypoint locations of the T (in [x0, y0, x1, y1, ...] format). The values are in the range [0, 512]. See
+    `get_keypoints` for a diagram showing the location of the keypoint indices.
 
     If `obs_type` is set to `pixels`, the observation space is a 96x96 RGB image of the environment.
 
@@ -186,7 +186,7 @@ class PushTEnv(gym.Env):
                 high=np.array([512, 512, 512, 512, 2 * np.pi]),
                 dtype=np.float64,
             )
-        elif self.obs_type == "keypoints":
+        elif self.obs_type == "environment_state":
             self.observation_space = spaces.Box(
                 low=np.zeros(8),
                 high=np.full((8,), 512),
@@ -375,7 +375,7 @@ class PushTEnv(gym.Env):
             block_angle = self.block.angle % (2 * np.pi)
             return np.concatenate([agent_position, block_position, [block_angle]], dtype=np.float64)
 
-        if self.obs_type == "keypoints":
+        if self.obs_type == "environment_state":
             return self.get_keypoints(self._block_shapes).flatten()
 
         pixels = self._render()

--- a/gym_pusht/envs/pusht.py
+++ b/gym_pusht/envs/pusht.py
@@ -376,7 +376,7 @@ class PushTEnv(gym.Env):
             return np.concatenate([agent_position, block_position, [block_angle]], dtype=np.float64)
 
         if self.obs_type == "keypoints":
-            return self.get_keypoints().flatten()
+            return self.get_keypoints(self._block_shapes).flatten()
 
         pixels = self._render()
         if self.obs_type == "pixels":
@@ -469,7 +469,7 @@ class PushTEnv(gym.Env):
         return body
 
     @staticmethod
-    def add_tee(self, space, position, angle, scale=30, color="LightSlateGray", mask=None):
+    def add_tee(space, position, angle, scale=30, color="LightSlateGray", mask=None):
         if mask is None:
             mask = pymunk.ShapeFilter.ALL_MASKS()
         mass = 1
@@ -502,7 +502,8 @@ class PushTEnv(gym.Env):
         space.add(body, shape1, shape2)
         return body, [shape1, shape2]
 
-    def get_keypoints(self):
+    @staticmethod
+    def get_keypoints(block_shapes):
         """Get a (8, 2) numpy array with the T keypoints.
 
         The T is composed of two rectangles each with 4 keypoints.
@@ -517,7 +518,7 @@ class PushTEnv(gym.Env):
             7───6
         """
         keypoints = []
-        for shape in self._block_shapes:
+        for shape in block_shapes:
             for v in shape.get_vertices():
                 v = v.rotated(shape.body.angle)
                 v = v + shape.body.position

--- a/gym_pusht/envs/pusht.py
+++ b/gym_pusht/envs/pusht.py
@@ -225,7 +225,8 @@ class PushTEnv(gym.Env):
             )
         else:
             raise ValueError(
-                f"Unknown obs_type {self.obs_type}. Must be one of [pixels, state, pixels_agent_pos]"
+                f"Unknown obs_type {self.obs_type}. Must be one of [pixels, state, environment_state_agent_pos, "
+                "pixels_agent_pos]"
             )
 
     def _get_coverage(self):

--- a/gym_pusht/envs/pusht.py
+++ b/gym_pusht/envs/pusht.py
@@ -56,9 +56,11 @@ class PushTEnv(gym.Env):
     environment: [agent_x, agent_y, block_x, block_y, block_angle]. The values are in the range [0, 512] for the agent
     and block positions and [0, 2*pi] for the block angle.
 
-    If `obs_type` is set to `environment_state` the observation space is a 16-dimensional vector representing the
-    keypoint locations of the T (in [x0, y0, x1, y1, ...] format). The values are in the range [0, 512]. See
-    `get_keypoints` for a diagram showing the location of the keypoint indices.
+    If `obs_type` is set to `environment_state_agent_pos` the observation space is a dictionary with:
+    - `environment_state`: 16-dimensional vector representing the keypoint locations of the T (in [x0, y0, x1, y1, ...]
+        format). The values are in the range [0, 512]. See `get_keypoints` for a diagram showing the location of the
+        keypoint indices.
+    - `agent_pos`: A 2-dimensional vector representing the position of the robot end-effector.
 
     If `obs_type` is set to `pixels`, the observation space is a 96x96 RGB image of the environment.
 
@@ -186,11 +188,20 @@ class PushTEnv(gym.Env):
                 high=np.array([512, 512, 512, 512, 2 * np.pi]),
                 dtype=np.float64,
             )
-        elif self.obs_type == "environment_state":
-            self.observation_space = spaces.Box(
-                low=np.zeros(16),
-                high=np.full((16,), 512),
-                dtype=np.float64,
+        elif self.obs_type == "environment_state_agent_pos":
+            self.observation_space = spaces.Dict(
+                {
+                    "environment_state": spaces.Box(
+                        low=np.zeros(16),
+                        high=np.full((16,), 512),
+                        dtype=np.float64,
+                    ),
+                    "agent_pos": spaces.Box(
+                        low=np.array([0, 0]),
+                        high=np.array([512, 512]),
+                        dtype=np.float64,
+                    ),
+                },
             )
         elif self.obs_type == "pixels":
             self.observation_space = spaces.Box(
@@ -375,8 +386,11 @@ class PushTEnv(gym.Env):
             block_angle = self.block.angle % (2 * np.pi)
             return np.concatenate([agent_position, block_position, [block_angle]], dtype=np.float64)
 
-        if self.obs_type == "environment_state":
-            return self.get_keypoints(self._block_shapes).flatten()
+        if self.obs_type == "environment_state_agent_pos":
+            return {
+                "environment_state": self.get_keypoints(self._block_shapes).flatten(),
+                "agent_pos": np.array(self.agent.position),
+            }
 
         pixels = self._render()
         if self.obs_type == "pixels":


### PR DESCRIPTION
This PR does two mostly disconnected things:

1. Adds an observation mode where keypoints and agent position are returned, as an alternative to `pixels_agent_pos` which returns an image and the agent position. This sort of keypoints-only environment allows us to circumvent using image encoders in the policy, which makes for a more agile experimentation setting.

2. Fixes the order of angle and position setting in `add_tee`.

You visualize the keypoints with this script:

```python
import cv2
import gymnasium as gym
import numpy as np

import gym_pusht

env = gym.make(
    "gym_pusht/PushT-v0",
    render_mode="rgb_array",
    obs_type="environment_state_agent_pos",
)
observation, info = env.reset()

for _ in range(1000):
    action = env.action_space.sample()
    observation, reward, terminated, truncated, info = env.step(action)
    image = env.render()
    if terminated or truncated:
        observation, info = env.reset()

    for kp in observation["environment_state"].reshape(8, 2):
        kp = np.round(kp / 512 * 680).astype(int)
        cv2.circle(image, tuple(kp), radius=4, color=(0, 0, 255), thickness=-1)
    cv2.imshow("window", image)
    k = cv2.waitKey(100)
    if k == ord("q"):
        break

env.close()
```

The reason 2 (fix order of ops in add_tee) is here, is because when generating the keypoints-only dataset using [this script](https://github.com/huggingface/lerobot/blob/74362ac453473d334c57444d9016640f9b30a860/lerobot/common/datasets/push_dataset_to_hub/pusht_zarr_format.py#L124-L144) I found out that the keypoints weren't aligned with the tee. In fact, I also discovered that the reward calculation was incorrect, for the same reason.