### PR TITLE
Add `success_threshold` parameter to adjust success criteria

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The reward is the coverage of the block in the goal zone. The reward is 1.0 if t
 
 ### Success Criteria
 
-The environment is considered solved if the block is at least 95% in the goal zone.
+By default, the environment is considered solved if the block is at least 95% in the goal zone. The percent can be configured via `success_threshold` parameter.
 
 ### Starting State
 
@@ -77,7 +77,7 @@ The agent starts at a random position and the block starts at a random position 
 
 ### Episode Termination
 
-The episode terminates when the block is at least 95% in the goal zone.
+The episode terminates when the success criteria is met.
 
 ### Arguments
 

--- a/gym_pusht/envs/pusht.py
+++ b/gym_pusht/envs/pusht.py
@@ -70,7 +70,7 @@ class PushTEnv(gym.Env):
 
     ## Success Criteria
 
-    The environment is considered solved if the block is at least 95% in the goal zone.
+    By default, the environment is considered solved if the block is at least 95% in the goal zone. The percent can be configured via `success_threshold` parameter.
 
     ## Starting State
 
@@ -78,7 +78,7 @@ class PushTEnv(gym.Env):
 
     ## Episode Termination
 
-    The episode terminates when the block is at least 95% in the goal zone.
+    The episode terminates when the success criteria is met.
 
     ## Arguments
 
@@ -104,6 +104,8 @@ class PushTEnv(gym.Env):
     * `visualization_width`: (int) The width of the visualized image. Default is `680`.
 
     * `visualization_height`: (int) The height of the visualized image. Default is `680`.
+
+    * `success_threshold`: (float) The percentage of block in goal zone required for environment to be considered solved. Default is `0.95`.
 
     ## Reset Arguments
 
@@ -144,6 +146,7 @@ class PushTEnv(gym.Env):
         observation_height=96,
         visualization_width=680,
         visualization_height=680,
+        success_threshold=0.95,
     ):
         super().__init__()
         # Observations
@@ -178,7 +181,7 @@ class PushTEnv(gym.Env):
         self.teleop = None
         self._last_action = None
 
-        self.success_threshold = 0.95  # 95% coverage
+        self.success_threshold = success_threshold
 
     def _initialize_observation_space(self):
         if self.obs_type == "state":


### PR DESCRIPTION
# Description
Added `success_threshold` as a parameter to `PushTEnv` (default value: `0.95`) so that the success criteria can be adjusted. Updated the `README.md` and docstrings to account for this. 

Ran `pre-commit` on the files.