### PR TITLE
fix: make reset deterministic

### DIFF
--- a/gym_pusht/envs/pusht.py
+++ b/gym_pusht/envs/pusht.py
@@ -273,13 +273,15 @@ class PushTEnv(gym.Env):
             state = np.array(options.get("reset_to_state"))
         else:
             # we use the env's RNG instead of global np.random
-            state = np.array([
-                self.np_random.integers(50, 450),
-                self.np_random.integers(50, 450),
-                self.np_random.integers(100, 400),
-                self.np_random.integers(100, 400),
-                self.np_random.uniform(-np.pi, np.pi),
-            ])
+            state = np.array(
+                [
+                    self.np_random.integers(50, 450),
+                    self.np_random.integers(50, 450),
+                    self.np_random.integers(100, 400),
+                    self.np_random.integers(100, 400),
+                    self.np_random.uniform(-np.pi, np.pi),
+                ]
+            )
         self._set_state(state)
 
         observation = self.get_obs()

--- a/gym_pusht/envs/pusht.py
+++ b/gym_pusht/envs/pusht.py
@@ -272,18 +272,14 @@ class PushTEnv(gym.Env):
         if options is not None and options.get("reset_to_state") is not None:
             state = np.array(options.get("reset_to_state"))
         else:
-            # state = self.np_random.uniform(low=[50, 50, 100, 100, -np.pi], high=[450, 450, 400, 400, np.pi])
-            rs = np.random.RandomState(seed=seed)
-            state = np.array(
-                [
-                    rs.randint(50, 450),
-                    rs.randint(50, 450),
-                    rs.randint(100, 400),
-                    rs.randint(100, 400),
-                    rs.randn() * 2 * np.pi - np.pi,
-                ],
-                # dtype=np.float64
-            )
+            # we use the env's RNG instead of global np.random
+            state = np.array([
+                self.np_random.integers(50, 450),
+                self.np_random.integers(50, 450),
+                self.np_random.integers(100, 400),
+                self.np_random.integers(100, 400),
+                self.np_random.uniform(-np.pi, np.pi),
+            ])
         self._set_state(state)
 
         observation = self.get_obs()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gym-pusht"
-version = "0.1.5"
+version = "0.1.6"
 description = "A gymnasium environment for PushT."
 authors = [
     "Rémi Cadène <re.cadene@gmail.com>",


### PR DESCRIPTION
At LeRobot, we will start using Gymnasium ≥ 1.x, which enforces deterministic seeding. hence, all environments must now be reproducible, the same seed must yield the same initial observation. In earlier gymnasium < 1.0 versions, this check was skipped, but with the new versions it is strictly validated