### PR TITLE
Replace pygame with pygame-ce for latest gymnasium compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ packages = [{include = "gym_pusht"}]
 python = "^3.10"
 gymnasium = ">=0.29.1"
 opencv-python = ">=4.9.0"
-pygame = ">=2.5.2"
+pygame-ce = ">=2.5.2"
 pymunk = ">=6.6.0"
 shapely = ">=2.0.3"
 scikit-image = ">=0.22.0"


### PR DESCRIPTION
The latest version of gymnasium, gymnasium 1.3.0, switched the extra that depended on pygame (that is kind of unmaintained) to pygame-ce (a drop-in maintained friendly fork), see https://github.com/Farama-Foundation/Gymnasium/pull/1512 . Depending on which extra of gymnasium are installed, this may result in both pygame and pygame-ce being installed, with the one actually installed and used depending on the order of installation.

To avoid this problem, this PR also updates gym-pusht to use pygame-ce in place of pygame.